### PR TITLE
Add shared lookup pages, Browse By navigation and release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# RESO Data Dictionary Documentation
+
+Static site generator for the [RESO Data Dictionary](https://dd.reso.org) documentation. Produces a browsable, searchable reference for DD fields, resources, lookups and cross-references across all published versions.
+
+## Features
+
+- Multi-version documentation (DD 1.7, 2.0, 2.1)
+- Resource and field detail pages with usage/adoption statistics
+- Shared lookup pages organized by LookupName
+- Browse By dimensions (Payload, Property Type, Element Status, Version Added)
+- Sortable tables, inline search filters and grouped field views
+- Dark/light theme toggle
+- Full-text search via [Pagefind](https://pagefind.app)
+- Mobile-optimized layout with sticky headers
+
+## Quick Start
+
+```bash
+npm install
+npm run fetch-data   # Download XLSX reference sheets
+npm run generate     # Generate static HTML
+```
+
+The generated site is written to `dd-output/`.
+
+## Data Sources
+
+- **Reference sheets**: XLSX files fetched from the [web-api-commander](https://github.com/RESOStandards/web-api-commander) repo
+- **Usage statistics**: Adoption data fetched from the RESO aggregation API (requires credentials)
+
+## Deployment
+
+The site is built and deployed automatically via GitHub Actions:
+
+| Trigger | Purpose |
+|---------|---------|
+| `repository_dispatch` | Rebuild when reference sheets change in the commander repo |
+| Weekly cron (Monday 6am UTC) | Refresh adoption/usage analytics |
+| `workflow_dispatch` | Manual on-demand builds |
+
+## Linting
+
+```bash
+npm run lint        # Check with Biome
+npm run lint:fix    # Auto-fix
+```
+
+## License
+
+See [LICENSE](LICENSE).

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,9 @@
+---
+title: Releases
+layout: default
+permalink: /releases/
+---
+
 # Releases
 
 ## v0.1.0 — Initial Release

--- a/generate.mjs
+++ b/generate.mjs
@@ -4772,18 +4772,23 @@ async function main() {
     console.warn('Error fetching usage stats:', err.message);
   }
 
-  // Derive total organizations per resource: the field with the most
-  // recipients is the best proxy for the total number of organizations
+  // TODO: Remove this local calculation once the aggs service exposes totalProviders directly.
+  // Derive total providers globally: find the max recipients across ALL resources/fields.
+  // This gives the true total number of organizations reporting data.
+  let globalTotalProviders = 0;
   if (usageStats) {
-    for (const [resourceName, resource] of Object.entries(usageStats)) {
-      let maxRecipients = 0;
+    for (const [, resource] of Object.entries(usageStats)) {
       for (const [key, stats] of Object.entries(resource)) {
         if (key === 'lookups' || !stats?.recipients) continue;
-        if (stats.recipients > maxRecipients) {
-          maxRecipients = stats.recipients;
+        if (stats.recipients > globalTotalProviders) {
+          globalTotalProviders = stats.recipients;
         }
       }
-      if (maxRecipients > 0) totalProvidersByResource[resourceName] = maxRecipients;
+    }
+    if (globalTotalProviders > 0) {
+      for (const resourceName of Object.keys(usageStats)) {
+        totalProvidersByResource[resourceName] = globalTotalProviders;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Shared lookup pages: index, per-LookupName and per-value pages with "Used By" tables
- Sidebar: Lookups section (flat list), Browse By section (renamed from Cross Reference)
- Field detail pages link to shared lookup pages instead of per-field duplicates
- Removed per-field duplicate lookup pages (~50% page count reduction)
- Table filter on Browse By value pages and LookupName pages
- Fix adoption calculation: use global max providers across all resources
- Usage column centering, pluralization fixes
- Updated header nav: Home, RESO Tools, RESO.org
- Biome linter with Lefthook pre-commit hooks
- README, RELEASES.md (served at /releases/), CLAUDE.md updates
- No hardcoded string constants

Closes #2

## Test plan

- [ ] Verify lookup index page (`/DD2.0/lookups/`)
- [ ] Verify LookupName page with values table and Used By section
- [ ] Verify shared lookup value page with per-field usage in Used By
- [ ] Verify field detail pages link to shared lookup pages
- [ ] Verify sidebar Lookups and Browse By sections expand/collapse correctly
- [ ] Verify table filter works on Browse By and LookupName pages
- [ ] Verify usage column is centered on all table types
- [ ] Verify singular/plural counts are correct
- [ ] Verify Biome lint passes (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)