### PR TITLE
Remove redundant header search button from generated pages (follow-up to #9)

### DIFF
--- a/generate.mjs
+++ b/generate.mjs
@@ -2080,7 +2080,6 @@ function getPageJS() {
         }
       }
 
-      document.getElementById('searchTrigger').addEventListener('click', openSearch);
       var sidebarSearchEl = document.getElementById('sidebarSearch');
       if (sidebarSearchEl) sidebarSearchEl.addEventListener('click', openSearch);
       overlay.addEventListener('click', function(e) { if (e.target === overlay) closeSearch(); });
@@ -3419,7 +3418,6 @@ function getLandingJS() {
         overlay.classList.remove('active');
         document.body.classList.remove('search-open');
       }
-      document.getElementById('searchTrigger').addEventListener('click', openSearch);
       document.getElementById('heroSearch').addEventListener('click', openSearch);
       overlay.addEventListener('click', function(e) { if (e.target === overlay) closeSearch(); });
       document.addEventListener('keydown', function(e) {
@@ -3482,10 +3480,6 @@ function wrapPage(title, version, sidebarHtml, contentHtml, allVersions, { pagef
     <nav class="header-nav" id="headerNav">
       <a href="/">Home</a>
       <a href="https://reso.org">RESO.org</a>
-      <button class="search-trigger" id="searchTrigger" type="button">
-        <svg viewBox="0 0 24 24"><path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
-        Search<kbd>/</kbd>
-      </button>
       <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle dark mode">
         <svg class="icon-moon" viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z"/></svg>
         <svg class="icon-sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
@@ -4975,10 +4969,6 @@ function generateDDLandingPage(allData) {
     <nav class="header-nav" id="headerNav">
       <a href="/">Home</a>
       <a href="https://reso.org">RESO.org</a>
-      <button class="search-trigger" id="searchTrigger" type="button">
-        <svg viewBox="0 0 24 24"><path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
-        Search<kbd>/</kbd>
-      </button>
       <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle dark mode">
         <svg class="icon-moon" viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z"/></svg>
         <svg class="icon-sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>


### PR DESCRIPTION
## Summary

Removes the header search trigger from the live-rendered pages. Follow-up to #9, which removed the button from `_layouts/default.html` but missed that **the live site does not use the Jekyll layout** — every page is rendered by `generate.mjs` (verified: served HTML at https://dd.reso.org/ still showed the trigger after #9 deployed).

## What the live build actually does

`generate.mjs` has three places that emit a `<header>` with the search trigger:

| Function | Pages |
|---|---|
| `wrapPage()` | every DD page (resources, fields, lookups, browse-by, about) |
| `generateDDLandingPage()` | the root `/` (`dd-output/index.html`) |
| `generate404Page()` | `dd-output/404.html` |

This PR removes the `<button class="search-trigger">` from all three. Also removes the matching `document.getElementById('searchTrigger').addEventListener(...)` calls in `getPageJS()` and `getLandingJS()` so the page JS does not throw `TypeError: Cannot read properties of null` once the button is gone.

## What's kept

- Sidebar search input on DD pages (`#sidebarSearch`) — still opens the search modal on click
- Hero search bar on the landing page (`#heroSearch`) — same
- The search modal markup, `openSearch` / `closeSearch`, the `/` keyboard shortcut, and Escape-to-close
- Theme toggle, hamburger menu

The in-page search bars (one per page) remain the way users get into search. Just no duplicate trigger in the global header.

## Local build check

```
$ npm run generate
...
  Generated 6635 pages (8 about, 4389 lookup, 25 browse-by)
  Generated DD landing page
  Generated 404 page
Done!

$ find dd-output -name "*.html" | xargs grep -l "searchTrigger\|search-trigger" | wc -l
0
```

## Test plan

- [ ] On preview, confirm the root `/`, a DD resource page, a field page, and the 404 page all show a header with no search button (only theme toggle + hamburger on mobile)
- [ ] Confirm the landing-page hero search box still opens the search modal
- [ ] Confirm the DD-page sidebar search input still opens the search modal
- [ ] Confirm `/` keyboard shortcut still opens the search modal
- [ ] Confirm Escape closes the search modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
